### PR TITLE
[4]- [Whatsapp-Module-frontend] Added menu and eDashboard

### DIFF
--- a/front-end/src/app/whatsapp-module/edashboard/edashboard.component.css
+++ b/front-end/src/app/whatsapp-module/edashboard/edashboard.component.css
@@ -1,0 +1,32 @@
+body, html {
+    margin: 0;
+    height: 100%;
+    font-family: Arial, sans-serif;
+}
+
+p {
+    font-size: 16px;
+    color: #333;
+    text-align: center;
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-bottom: 1px solid #ccc;
+    margin: 0;
+}
+
+.container {
+    display: flex;
+    height: 87vh;
+}
+
+.menu {
+    flex: 1;
+    border-right: 1px solid #ccc;
+    background-color: #f1f1f1;
+}
+
+.content {
+    flex: 4;
+    padding: 20px;
+    background-color: #fff;
+}

--- a/front-end/src/app/whatsapp-module/edashboard/edashboard.component.html
+++ b/front-end/src/app/whatsapp-module/edashboard/edashboard.component.html
@@ -1,0 +1,6 @@
+<div class="container">
+
+  <div class="menu">
+    <app-whatsapp-menu></app-whatsapp-menu>
+  </div>
+</div>  

--- a/front-end/src/app/whatsapp-module/edashboard/edashboard.component.spec.ts
+++ b/front-end/src/app/whatsapp-module/edashboard/edashboard.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {  EdashboardWhatsAppComponent } from './edashboard.component';
+
+describe(' EdashboardWhatsAppComponent', () => {
+  let component:  EdashboardWhatsAppComponent;
+  let fixture: ComponentFixture< EdashboardWhatsAppComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ EdashboardWhatsAppComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent( EdashboardWhatsAppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/edashboard/edashboard.component.ts
+++ b/front-end/src/app/whatsapp-module/edashboard/edashboard.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { WhatsAppMenuComponent } from '../menu/whatsapp-menu.component';
+import { RouterModule } from '@angular/router';
+
+
+@Component({
+  selector: 'app-edashboard',
+  standalone: true,
+  imports: [WhatsAppMenuComponent,RouterModule],
+  templateUrl: './edashboard.component.html',
+  styleUrl: './edashboard.component.css'
+})
+export class EdashboardWhatsAppComponent {
+
+}
+
+
+
+

--- a/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.css
+++ b/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.css
@@ -1,0 +1,92 @@
+body, html {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+    height: 100%;
+    width: 100%;
+}
+
+p {
+    font-size: 16px;
+    color: #fff;
+    text-align: center;
+    padding: 20px;
+    background-color: #007bff;
+    border-bottom: 1px solid #ccc;
+    margin: 0;
+}
+
+
+.menu {
+    display: flex;
+    height: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+    overflow-x: hidden;
+}
+
+.container-fluid {
+    display: flex;
+    flex: 1;
+    flex-direction: row; /* Changed to row to align sidebar and main content side by side */
+    height: 100%;
+}
+
+.row {
+    display: flex;
+    flex: 1;
+    flex-direction: row; /* Ensure row direction */
+}
+
+.sidebar {
+    flex: 0 0 300px;
+    border-right: 1px solid #ccc;
+    background-color: #ffffff;
+    padding-top: 20px;
+    overflow-y: auto;
+}
+
+.sidebar .position-sticky {
+    position: sticky;
+    top: 0;
+}
+
+.nav {
+    display: flex;
+    flex-direction: column;
+    padding-left: 0;
+    list-style: none;
+    margin: 0;
+}
+
+.nav-item {
+    width: 100%;
+}
+
+.nav-link {
+    display: block;
+    padding: 10px 20px;
+    color: #333;
+    text-decoration: none;
+    transition: background-color 0.3s ease;
+    cursor: pointer;
+}
+
+.nav-link:hover {
+    background-color: #e0e0e0;
+}
+
+.nav-link.active {
+    background-color: #007bff;
+    color: #fff;
+}
+
+.main-content {
+    flex: 1; /* Takes the remaining space */
+    padding: 20px;
+    background-color: #fde5cd;
+    overflow-y: auto;
+}
+
+
+

--- a/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.html
+++ b/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.html
@@ -1,0 +1,43 @@
+<div class="menu">
+    <div class="container-fluid">
+        <div class="row">
+            <!-- Sidebar -->
+            <div class="sidebar">
+                <div class="position-sticky">
+                    <ul class="nav flex-col">
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'select-template'" (click)="selectMenu('select-template')">Select Template</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'create-template'" (click)="selectMenu('create-template')">Create Template</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'configure-template'" (click)="selectMenu('configure-template')">Configure Template</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'select-recipients'" (click)="selectMenu('select-recipients')">Select Recipients</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'upload-user-data'" (click)="selectMenu('upload-user-data')">Upload User Data</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" [class.active]="selectedMenu === 'preview-and-send'" (click)="selectMenu('preview-and-send')">Preview and Send</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Main content -->
+            <main class="main-content">
+                <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+                    <app-select-template *ngIf="selectedMenu === 'select-template'"></app-select-template>
+                    <app-create-WhatsApp-template *ngIf="selectedMenu === 'create-template'"></app-create-WhatsApp-template>
+                    <app-configure-WhatsApp-template *ngIf="selectedMenu === 'configure-template'"></app-configure-WhatsApp-template>
+                    <app-view-WhatsApp-user-data *ngIf="selectedMenu === 'select-recipients'"></app-view-WhatsApp-user-data>
+                    <app-upload-WhatsApp-user-data *ngIf="selectedMenu === 'upload-user-data'"></app-upload-WhatsApp-user-data>
+                    <app-send-whatsapp *ngIf="selectedMenu === 'preview-and-send'"></app-send-whatsapp>
+                </div>
+            </main>
+        </div>
+    </div>
+</div>

--- a/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.spec.ts
+++ b/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WhatsAppMenuComponent } from './whatsapp-menu.component';
+
+
+
+describe('WhatsAppMenuComponent', () => {
+  let component: WhatsAppMenuComponent;
+  let fixture: ComponentFixture<WhatsAppMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WhatsAppMenuComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(WhatsAppMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.ts
+++ b/front-end/src/app/whatsapp-module/menu/whatsapp-menu.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ConfigureWhatsAppTemplateComponent } from '../configure-template/configure-template.component';
+import { CreateWhatsAppTemplateComponent } from '../create-template/create-template.component';
+import { EdashboardWhatsAppComponent } from '../edashboard/edashboard.component';
+import { HistoryComponent } from "../../email-module/history/history.component";
+import { UploadWhatsappUserDataComponent } from '../upload-user-data/upload-user-data.component';
+import { ViewWhatsAppUserDataComponent } from '../view-user-data/view-user-data.component';
+import { SendWhatsAppComponent } from "../send-whatsapp/send-whatsapp.component";
+import { SelectTemplateComponent } from "../select-template/select-template.component";
+
+@Component({
+  selector: 'app-whatsapp-menu',
+  standalone: true,
+  imports: [CommonModule, ConfigureWhatsAppTemplateComponent, CreateWhatsAppTemplateComponent, EdashboardWhatsAppComponent, UploadWhatsappUserDataComponent, ViewWhatsAppUserDataComponent, SendWhatsAppComponent, SelectTemplateComponent],
+  templateUrl: './whatsapp-menu.component.html',
+  styleUrl: './whatsapp-menu.component.css'
+})
+export class WhatsAppMenuComponent {
+  selectedMenu: string = 'select-template';
+
+  selectMenu(option: string) {  
+  this.selectedMenu = option;
+  }
+}


### PR DESCRIPTION
In this PR I have added the following frontend components for the Whatsapp Module:
1) Edashboard: This is the landing page for the user after selecting medium- WhatsApp
2) Menu: It is the sidebar menu from where user can traverse through the features available for the WhatsApp module