### PR TITLE
[4]- [Whatsapp-Module-frontend] Added Create,Select template and Service required

### DIFF
--- a/front-end/src/app/whatsapp-module/Services/braces-transform.pipe.spec.ts
+++ b/front-end/src/app/whatsapp-module/Services/braces-transform.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { BracesTransformPipe } from './braces-transform.pipe';
+
+describe('BracesTransformPipe', () => {
+  it('create an instance', () => {
+    const pipe = new BracesTransformPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/Services/braces-transform.pipe.ts
+++ b/front-end/src/app/whatsapp-module/Services/braces-transform.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'removeBraces',
+  standalone: true
+})
+export class RemoveBracesPipe implements PipeTransform {
+
+  transform(value: string): string {
+    if (!value) return '';
+
+    const dynamicFieldsCount = value.match(/{{\d+}}/g)?.length || 0;
+    let transformedValue = value;
+
+    for (let i = 1; i <= dynamicFieldsCount; i++) {
+      const placeholder = `{{${i}}}`;
+      const replacement = `<span class="example-text">Field-${i}</span>`;
+      transformedValue = transformedValue.replace(placeholder, replacement);
+    }
+
+    return transformedValue;
+  }
+
+}

--- a/front-end/src/app/whatsapp-module/Services/data-service.service.spec.ts
+++ b/front-end/src/app/whatsapp-module/Services/data-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DataServiceService } from './data-service.service';
+
+describe('DataServiceService', () => {
+  let service: DataServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DataServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/Services/data-service.service.ts
+++ b/front-end/src/app/whatsapp-module/Services/data-service.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DataServiceService {
+
+  constructor() { }
+}

--- a/front-end/src/app/whatsapp-module/Services/navigator.service.spec.ts
+++ b/front-end/src/app/whatsapp-module/Services/navigator.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NavigatorService } from './navigator.service';
+
+describe('NavigatorService', () => {
+  let service: NavigatorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavigatorService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/Services/navigator.service.ts
+++ b/front-end/src/app/whatsapp-module/Services/navigator.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NavigatorService {
+
+  constructor() { }
+  SelectedTemplate:string | null= null;
+  private SelectedUsers: any[] = []; 
+  SelectedOption:string="select-template";
+
+  getSelectedTemplate():string|null{
+    return this.SelectedTemplate;
+  }
+  getSelectedUsers(): any[] {
+    return this.SelectedUsers;
+  }
+  getSelectedOption():string|null{
+    return this.SelectedOption;
+  }
+
+  setSelectedTemplate(template:string):void{
+    this.SelectedTemplate=template;
+  }
+  setSelectedUsers(users: any[]): void {
+    console.log("Selected users list is changed");
+    this.SelectedUsers = users;
+  }
+  setSelectedOption(option:string):void{
+    this.SelectedOption=option;
+  }
+
+}

--- a/front-end/src/app/whatsapp-module/Services/whatsapp-service.service.spec.ts
+++ b/front-end/src/app/whatsapp-module/Services/whatsapp-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { WhatsappServiceService } from './whatsapp-service.service';
+
+describe('WhatsappServiceService', () => {
+  let service: WhatsappServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(WhatsappServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/Services/whatsapp-service.service.ts
+++ b/front-end/src/app/whatsapp-module/Services/whatsapp-service.service.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { PropServiceService } from '../../services/prop-service.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WhatsappTemplateService {
+
+  private apiUrl = 'http://localhost:5000/api/whatsapp'; // Corrected the base URL
+
+  constructor(private http: HttpClient, private propService: PropServiceService) { }
+
+  getTemplates(): Observable<any> {
+    const senderNumber = this.propService.getSenderNumber();
+    if (!senderNumber) {
+      throw new Error('Sender number is not set');
+    }
+    const params = new HttpParams().set('senderNumber', senderNumber);
+    return this.http.get(`${this.apiUrl}/templates`, {withCredentials:true, params });
+  }
+
+  getSingleTemplate(templateId: string): Observable<any> {
+    const senderNumber = this.propService.getSenderNumber();
+    if (!senderNumber) {
+      throw new Error('Sender number is not set');
+    }
+    let params = new HttpParams().set('senderNumber', senderNumber);
+    params = params.append('templateId', templateId);
+    return this.http.get(`${this.apiUrl}/template`, { withCredentials: true,params });
+  }
+
+  createTemplate(template: any): Observable<any> {
+    const senderNumber = this.propService.getSenderNumber();
+    if (!senderNumber) {
+      throw new Error('Sender number is not set');
+    }
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    const body = { senderNumber, ...template };
+    return this.http.post(`${this.apiUrl}/template/create`, body, { headers,withCredentials:true, });
+  }
+
+  deleteTemplate(id: string): Observable<any> {
+    const senderNumber = this.propService.getSenderNumber();
+    if (!senderNumber) {
+      throw new Error('Sender number is not set');
+    }
+    const body = { senderNumber };
+    return this.http.request('delete', `${this.apiUrl}/template/delete/${id}`, { body });
+  }
+
+  modifyTemplate(template: any): Observable<any> {
+    const senderNumber = this.propService.getSenderNumber();
+    if (!senderNumber) {
+      throw new Error('Sender number is not set');
+    }
+    const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    const body = { senderNumber, ...template };
+    return this.http.patch(`${this.apiUrl}/template/modify`, body, { headers, withCredentials: true });
+}
+
+
+  sendMessage(messageData: any): Observable<any> {
+    console.log("This data will be passed to backend: ",messageData)
+    return this.http.post(`${this.apiUrl}/message`, messageData, { withCredentials:true});
+  }
+}

--- a/front-end/src/app/whatsapp-module/create-template/create-template.component.css
+++ b/front-end/src/app/whatsapp-module/create-template/create-template.component.css
@@ -1,0 +1,74 @@
+body {
+  font-family: Arial, sans-serif;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.form input,
+textarea,
+select {
+  width: 300px;
+  border-radius: 5px;
+  border: none;
+  padding: 10px;
+}
+
+select {
+  font-family: 'Poppins', sans-serif;
+}
+select option{
+  font-family: 'Poppins', sans-serif;
+}
+
+.form input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+}
+
+.fields {
+  width: 60%;
+  display: flex;
+  align-items: center;
+  gap: 5rem;
+  justify-content: space-between;
+  padding-inline: 10px;
+}
+
+
+
+.ExampleAdder button {
+  height: 40px;
+  width: 100px;
+  background-color: rgb(189, 188, 188);
+  border: none;
+  border-radius: 10px;
+  font-size: 15px;
+  cursor: pointer;
+}
+
+.SubmitButton button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
+  min-width: 50px;
+  padding: 20px;
+  border-radius: 30px;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  color: white;
+  font-size: 18px;
+  border: solid #184486 2px;
+  background-color: #184486;
+}
+
+.SubmitButton button:active {
+  background-color: #082754;
+  scale: 90%;
+}

--- a/front-end/src/app/whatsapp-module/create-template/create-template.component.html
+++ b/front-end/src/app/whatsapp-module/create-template/create-template.component.html
@@ -1,0 +1,31 @@
+<div>
+    <h1><strong>Create New Template</strong></h1>
+    <form (ngSubmit)="onSubmit()" #templateForm="ngForm" class="form">
+        <div class="fields">
+            <label for="name">Template Name:</label>
+            <input type="text" id="name" [(ngModel)]="name" name="name" required>
+        </div>
+        <div class="fields">
+            <label for="category">Category:</label>
+            <select id="category" [(ngModel)]="category" name="category" required>
+                <option value="UTILITY">UTILITY</option>
+                <option value="MARKETING">MARKETING</option>
+                <option value="AUTHENTICATION">AUTHENTICATION</option>
+            </select>
+        </div>
+        <div class="fields body">
+            <label for="bodyText">Body Text:</label>
+            <textarea id="bodyText" [(ngModel)]="bodyText" name="bodyText" required></textarea>
+        </div>
+        <div *ngFor="let example of examples; let i = index" class="fields">
+            <label for="example{{i}}">Example {{i + 1}}:</label>
+            <input type="text" id="example{{i}}" [(ngModel)]="examples[i]" name="example{{i}}">
+        </div>
+        <div class="ExampleAdder">
+            <button type="button" (click)="addExample()">Add Example</button>
+        </div>
+        <div class="SubmitButton">
+            <button type="submit">Submit</button>
+        </div>
+    </form>
+</div>

--- a/front-end/src/app/whatsapp-module/create-template/create-template.component.spec.ts
+++ b/front-end/src/app/whatsapp-module/create-template/create-template.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import {CreateWhatsAppTemplateComponent } from './create-template.component';
+
+describe('CreateWhatsappTemplateComponent', () => {
+  let component: CreateWhatsAppTemplateComponent;
+  let fixture: ComponentFixture<CreateWhatsAppTemplateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreateWhatsAppTemplateComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreateWhatsAppTemplateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/create-template/create-template.component.ts
+++ b/front-end/src/app/whatsapp-module/create-template/create-template.component.ts
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { FormBuilder, FormGroup, Validators, FormArray } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { PropServiceService } from '../../services/prop-service.service';
+import { WhatsappTemplateService } from '../Services/whatsapp-service.service';
+
+@Component({
+  selector: 'app-create-WhatsApp-template',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule
+  ],
+  templateUrl: './create-template.component.html',
+  styleUrls: ['./create-template.component.css']
+})
+export class CreateWhatsAppTemplateComponent {
+  isClosing:boolean=false;
+  
+  senderNumber: string | null = null;
+  name: string = '';
+  language: string = 'en';
+  category: string = '';
+  allowCategoryChange: boolean = false;
+  bodyText: string = '';
+  examples: string[] = [''];
+
+  constructor(
+    private http: HttpClient,
+    private propService: PropServiceService,
+    private whatsappService: WhatsappTemplateService,
+  ) {}
+
+  ngOnInit() {
+    this.senderNumber = this.propService.getSenderNumber();
+  }
+
+  addExample() {
+    this.examples.push('');
+  }
+
+  onSubmit() {
+    const templateData = {
+      senderNumber: this.senderNumber,
+      name: this.name,
+      language: this.language,
+      category: this.category,
+      allowCategoryChange: this.allowCategoryChange,
+      structure: {
+        body: {
+          text: this.bodyText,
+          examples: this.examples.filter(example => example !== '')
+        },
+        type: 'TEXT'
+      }
+    };
+    console.log('Template creation started');
+    console.log(templateData.structure.body.examples)
+    this.whatsappService.createTemplate(templateData).subscribe(
+      data => {
+        console.log(data);
+        alert("Template Created Successfully!")
+      },
+      error => {
+        console.error('Error:', error);
+        alert("Some error occurred while creating template!")
+        console.log("Template was not creatred because: ",error)
+      }
+    );
+  }
+
+
+}

--- a/front-end/src/app/whatsapp-module/select-template/select-template.component.css
+++ b/front-end/src/app/whatsapp-module/select-template/select-template.component.css
@@ -1,0 +1,186 @@
+body {
+    font-family: Arial, sans-serif;
+    /* Default font for the entire body */
+  }
+  
+  .Container {
+    background-color: #FDE5CD;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
+    box-sizing: border-box;
+  }
+  .Upper{
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .Upper h2 {
+    margin-inline: 3rem;
+    padding-inline: 0.5rem;
+  }
+  
+  .Header {
+    display: flex;
+    justify-content: space-between;
+    padding-inline: 1.5rem;
+    margin-inline: 2rem;
+  }
+  
+  .Header button {
+    height: 65%;
+    margin-right: 15px;
+    padding: 10px;
+    border-radius: 30px;
+    font-family: 'Poppins', sans-serif;
+    cursor: pointer;
+    color: #184486;
+    font-weight: bold;
+    border: solid #184486 2px;
+    background-color: transparent;
+  }
+  
+  .Header button:hover {
+    background-color: #184486;
+    color: white;
+  }
+  
+  .SubContainer{
+    margin-top:3rem ;
+  }
+  
+  .SubContainer .Prev{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 40%;
+    left: 10px;
+    border-radius: 40px;
+    padding: 10px;
+    border: solid gray;
+    font-size: 20px;
+    cursor: pointer;
+  }
+  
+  .SubContainer .Next {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 40%;
+    right: 10px;
+    border-radius: 40px;
+    padding: 10px;
+    border: solid gray;
+    font-size: 20px;
+    cursor: pointer;
+  }
+  .SubContainer button:hover{
+    background-color: #1B4CA1;
+  
+  }
+  
+  .CardsSection {
+    display: grid;
+    margin-inline: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem; /* Adjust the gap as needed */
+  }
+  
+  /*These are the properties for scrollbar*/
+  .CardsSection::-webkit-scrollbar {
+    height: 12px;
+    /* Height of the horizontal scrollbar */
+  }
+  
+  .CardsSection::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    /* Background of the scrollbar track */
+    border-radius: 10px;
+    /* Rounded edges for the scrollbar track */
+  }
+  
+  .CardsSection::-webkit-scrollbar-thumb {
+    background: #888;
+    /* Color of the scroller */
+    border-radius: 10px;
+    /* Rounded edges for the scroller */
+  }
+  
+  .CardsSection::-webkit-scrollbar-thumb:hover {
+    background: #555;
+    /* Color of the scroller on hover */
+  }
+  
+  .Card {
+    min-height: 150px;
+    min-width: 200px;
+    background-color: white;
+    border-radius: 10px;
+    padding-inline: 1rem;
+    cursor: pointer;
+    font-family: 'Roboto Mono', monospace;
+    margin-bottom: 2rem;
+    flex: 0 0 calc(25% - 20px);
+    /* Adjust width based on number of cards per view */
+    margin-right: 20px;
+    padding: 15px;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+  }
+  
+  .Card:hover {
+    background-color: #d4d9e0;
+  }
+  
+  .CardUpper {
+    display: flex;
+    justify-content: space-between;
+  }
+  
+  .CardUpper input[type="radio"] {
+    accent-color: black;
+    transform: scale(1.5);
+    height: 20px;
+    width: 13px;
+  }
+  
+  :host ::ng-deep .example-text {
+    color: red;
+  }
+  
+  .SubmitButton {
+    position: fixed;
+    bottom: 0px;
+    right: 0px;
+    display: flex;
+    justify-content: right;
+    padding: 1.5rem;
+  }
+  
+  .SubmitButton button {
+    margin-right: 2rem;
+    padding: 0.7rem;
+    padding-inline: 4rem;
+    background-color: #0a316c;
+    border: none;
+    border-radius: 10px;
+    color: white;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  
+  .SubmitButton button:hover {
+    background-color: #06285b;
+  }
+  
+  .SubmitButton button:disabled {
+    cursor: not-allowed;
+  }
+  
+  :host ::ng-deep .highlight {
+    color: #1B4CA1;
+    font-weight: 500;
+  }

--- a/front-end/src/app/whatsapp-module/select-template/select-template.component.html
+++ b/front-end/src/app/whatsapp-module/select-template/select-template.component.html
@@ -1,0 +1,36 @@
+<div>
+    <div class="Container">
+        <div class="Upper">
+            <h2>Whatsapp Service Templates</h2>
+            <div class="Header">
+                <h3>Choose Template</h3>
+                <button>Create New Template</button>
+            </div>
+        </div>
+        <div class="Lower">
+            <div class="SubContainer">
+                <div class="CardsSection">
+                    <div class="Card" *ngFor="let template of templates"
+                        (click)="selectTemplate(template)">
+                        <div class="CardUpper">
+                            <div class="TemplateId">
+                                <h3>Template Id</h3>
+                                <h4>{{ template.id }}</h4>
+                            </div>
+                            <input type="radio" name="selectedTemplate" [checked]="selectedTemplateId === template.id"
+                                (click)="onRadioClick(template.id)">
+                            <span class="radio-checkmark"></span>
+                        </div>
+                        <div>
+                            <span><strong>Name:</strong> {{template.name}}</span>
+                        </div>
+                        <p [innerHTML]="template.structure.body.text | removeBraces"></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="SubmitButton">
+            <button [disabled]="!selectedTemplateId" (click)="navigate()">Select</button>
+        </div>
+    </div>
+</div>

--- a/front-end/src/app/whatsapp-module/select-template/select-template.component.spec.ts
+++ b/front-end/src/app/whatsapp-module/select-template/select-template.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectTemplateComponent } from './select-template.component';
+
+describe('SelectTemplateComponent', () => {
+  let component: SelectTemplateComponent;
+  let fixture: ComponentFixture<SelectTemplateComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SelectTemplateComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SelectTemplateComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/front-end/src/app/whatsapp-module/select-template/select-template.component.ts
+++ b/front-end/src/app/whatsapp-module/select-template/select-template.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit } from '@angular/core';
+import { Router, RouterModule } from '@angular/router';
+import { WhatsappTemplateService } from '../Services/whatsapp-service.service';
+import { PropServiceService } from '../../services/prop-service.service';
+import { RemoveBracesPipe } from '../Services/braces-transform.pipe';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { NavigatorService } from '../Services/navigator.service';
+
+@Component({
+  selector: 'app-select-template',
+  standalone: true,
+  imports: [RouterModule, CommonModule, FormsModule, RemoveBracesPipe],
+  templateUrl: './select-template.component.html',
+  styleUrls: ['./select-template.component.css']
+})
+export class SelectTemplateComponent implements OnInit {
+  templates: any = null;
+  selectedTemplateId: string | null = null;
+  loading: boolean = true;
+  currentPage: number = 0;
+  totalPages: number = 1;
+  pageSize: number = 4;
+  templatesLoaded: boolean = false;
+  showPopup: boolean = false;
+
+  constructor(
+    private whatsappService: WhatsappTemplateService,
+    private propService: PropServiceService,
+    private router: Router,
+    private navigatorService: NavigatorService
+  ) {}
+
+  ngOnInit(): void {
+    this.getTemplates();
+    const Templateid=this.navigatorService.getSelectedTemplate();
+    if(Templateid!=null){
+      this.selectedTemplateId=Templateid;
+    }
+  }
+
+  getTemplates(): void {
+    this.whatsappService.getTemplates().subscribe(
+      data => {
+        this.templates = data.templates;
+        console.log(data);
+        this.templatesLoaded = true;
+      },
+      error => console.error('Error:', error)
+    );
+    this.loading = false;
+  }
+
+  onRadioClick(templateId: string): void {
+    this.selectedTemplateId = templateId;
+  }
+
+  selectTemplate(template: any): void {
+    this.propService.setSelectedTemplate(template);
+    this.selectedTemplateId = template.id;
+  }
+
+  createTemplate(): void {
+    this.router.navigate(['dashboard/whatsapp/create']);
+  }
+
+  navigate(): void {
+    if (this.selectedTemplateId) {
+      console.log("Now going to send message component!");
+      console.log(this.navigatorService.getSelectedOption());
+      this.navigatorService.setSelectedTemplate(this.selectedTemplateId);
+      this.navigatorService.setSelectedOption("upload-user-data");
+      console.log("This is selected option:", this.navigatorService.getSelectedOption());
+    } else {
+      console.log("Please select a template first then click submit!");
+    }
+  }
+}


### PR DESCRIPTION
In this PR I have added the following things:
1) Create template component: The component which is used to create a new template, with implementation of text editor space and other required fields and it sends request through the API and payload logics written in `Services` component
2) It is the components where all existing templates are fetched by API logics written in `Services` and user can select any template to proceed with